### PR TITLE
Updated to netstandard2.0

### DIFF
--- a/src/ShareFile.Api.Client/Models/AccountPreferences.cs
+++ b/src/ShareFile.Api.Client/Models/AccountPreferences.cs
@@ -653,27 +653,27 @@ namespace ShareFile.Api.Client.Models
 				}
 				if(source.TryGetProperty("PasswordMaxAgeDays", out token) && token.Type != JTokenType.Null)
 				{
-					PasswordMaxAgeDays = (int)serializer.Deserialize(token.CreateReader(), typeof(int));
+					PasswordMaxAgeDays = PasswordPolicy.MaxAgeDays.GetValueOrDefault();
 				}
 				if(source.TryGetProperty("PasswordHistoryCount", out token) && token.Type != JTokenType.Null)
 				{
-					PasswordHistoryCount = (int)serializer.Deserialize(token.CreateReader(), typeof(int));
+					PasswordHistoryCount = PasswordPolicy.HistoryCount.GetValueOrDefault();
 				}
 				if(source.TryGetProperty("MinimumLength", out token) && token.Type != JTokenType.Null)
 				{
-					MinimumLength = (int)serializer.Deserialize(token.CreateReader(), typeof(int));
+					MinimumLength = PasswordPolicy.MinimumLength.GetValueOrDefault();
 				}
 				if(source.TryGetProperty("MinimumSpecialCharacters", out token) && token.Type != JTokenType.Null)
 				{
-					MinimumSpecialCharacters = (int)serializer.Deserialize(token.CreateReader(), typeof(int));
+					MinimumSpecialCharacters = PasswordPolicy.MinimumSpecialCharacters.GetValueOrDefault();
 				}
 				if(source.TryGetProperty("MinimumNumeric", out token) && token.Type != JTokenType.Null)
 				{
-					MinimumNumeric = (int)serializer.Deserialize(token.CreateReader(), typeof(int));
+					MinimumNumeric = PasswordPolicy.MinimumNumeric.GetValueOrDefault();
 				}
 				if(source.TryGetProperty("AllowedSpecialCharacters", out token) && token.Type != JTokenType.Null)
 				{
-					AllowedSpecialCharacters = (string)serializer.Deserialize(token.CreateReader(), typeof(string));
+					AllowedSpecialCharacters = PasswordPolicy.AllowedSpecialCharacters;
 				}
 				if(source.TryGetProperty("PasswordPolicy", out token) && token.Type != JTokenType.Null)
 				{

--- a/src/ShareFile.Api.Client/ShareFile.Api.Client.csproj
+++ b/src/ShareFile.Api.Client/ShareFile.Api.Client.csproj
@@ -3,92 +3,29 @@
   <Import Project="..\NuGetInfo.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net462;netstandard1.3;portable-net45+win8+wpa81</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>ShareFile.Api.Client</AssemblyName>
     <PackageId>ShareFile.Api.Client</PackageId>
     <PackageTags>ShareFile</PackageTags>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <NoWarn>1701;1702;1705;1591;1571;1572;1573;1570</NoWarn>
+    <NoWarn>1701;1702;1705;1591;1571;1572;1573;1570;AD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Remove="Internal\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'portable-net45+win8+wpa81' ">
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <Reference Include="mscorlib" />
-    <Reference Include="System.Collections" />
-    <Reference Include="System.ComponentModel" />
-    <Reference Include="System.Diagnostics.Debug" />
-    <Reference Include="System.Dynamic.Runtime" />
-    <Reference Include="System.Globalization" />
-    <Reference Include="System.IO" />
-    <Reference Include="System.Linq" />
-    <Reference Include="System.Linq.Expressions" />
-    <Reference Include="System.Linq.Queryable" />
-    <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Primitives" />
-    <Reference Include="System.Net.Requests" />
-    <Reference Include="System.ObjectModel" />
-    <Reference Include="System.Reflection" />
-    <Reference Include="System.Reflection.Extensions" />
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Runtime.Extensions" />
-    <Reference Include="System.Text.Encoding" />
-    <Reference Include="System.Text.RegularExpressions" />
-    <Reference Include="System.Threading" />
-    <Reference Include="System.Threading.Tasks" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Security" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Security" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'portable-net45+win8+wpa81' ">
-    <TargetFrameworkIdentifier>.NETPortable</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <NugetTargetMoniker>.NETPortable,Version=v0.0,Profile=Profile111</NugetTargetMoniker>
-    <DefineConstants>$(DefineConstants);PORTABLE;ASYNC;NETFX_CORE</DefineConstants>
-    <LanguageTargets>$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets</LanguageTargets>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);ASYNC;NETFX_CORE</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <DefineConstants>$(DefineConstants);ASYNC;NETFX_CORE</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);ASYNC;NETFX_CORE</DefineConstants>
-  </PropertyGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-  </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FUR10N.NullContracts" Version="1.0.0-beta5">
-        <PrivateAssets>All</PrivateAssets>
+    <PackageReference Include="FUR10N.NullContracts" Version="1.3.4">
+      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Buffers" Version="4.4.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ShareFile.Api.Client/Transfers/Downloaders/AsyncMemoryMappedFileDownloader.cs
+++ b/src/ShareFile.Api.Client/Transfers/Downloaders/AsyncMemoryMappedFileDownloader.cs
@@ -38,7 +38,6 @@ namespace ShareFile.Api.Client.Transfers.Downloaders
                 mapName: null,
                 capacity: fileSize,
                 access: MemoryMappedFileAccess.ReadWrite,
-                memoryMappedFileSecurity: null,
                 inheritability: HandleInheritability.None,
                 leaveOpen: false);
         }

--- a/src/ShareFile.Api.Client/Transfers/StreamWrapper.cs
+++ b/src/ShareFile.Api.Client/Transfers/StreamWrapper.cs
@@ -2,9 +2,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-#if !PORTABLE && !NETSTANDARD1_3
-using System.Runtime.Remoting;
-#endif
 
 namespace ShareFile.Api.Client.Transfers
 {
@@ -45,7 +42,7 @@ namespace ShareFile.Api.Client.Transfers
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
             => stream.BeginWrite(buffer, offset, count, callback, state);
         public override void Close() => stream.Close();
-        public override ObjRef CreateObjRef(Type requestedType) => stream.CreateObjRef(requestedType);
+        //public System.Runtime.Remoting.ObjRef CreateObjRef(Type requestedType) => stream.CreateObjRef(requestedType);
         public override int EndRead(IAsyncResult asyncResult) => stream.EndRead(asyncResult);
         public override void EndWrite(IAsyncResult asyncResult) => stream.EndWrite(asyncResult);
         public override object InitializeLifetimeService() => stream.InitializeLifetimeService();

--- a/src/ShareFile.Api.Client/Transfers/Uploaders/AsyncMemoryMappedFileUploader.cs
+++ b/src/ShareFile.Api.Client/Transfers/Uploaders/AsyncMemoryMappedFileUploader.cs
@@ -75,7 +75,6 @@ namespace ShareFile.Api.Client.Transfers.Uploaders
                 mapName: Guid.NewGuid().ToString(), // no collisions with other files
                 capacity: 0, // disk file size
                 access: MemoryMappedFileAccess.Read,
-                memoryMappedFileSecurity: null, // docs say ok 
                 inheritability: HandleInheritability.None, // single process
                 leaveOpen: true); // caller disposes filestream
         }


### PR DESCRIPTION
portable targets are obsolete: https://docs.microsoft.com/en-us/nuget/reference/target-frameworks#portable-class-libraries