### PR TITLE
Retrieve Shared Folders for a Specific User

### DIFF
--- a/src/ShareFile.Api.Client/Entities/UsersEntity.cs
+++ b/src/ShareFile.Api.Client/Entities/UsersEntity.cs
@@ -1266,6 +1266,24 @@ namespace ShareFile.Api.Client.Entities
             sfApiQuery.HttpMethod = "GET";	
             return sfApiQuery;
         }
+
+        /// <summary>
+        /// Get List of User Shared Folders
+        /// </summary>
+        /// <remarks>
+        /// Retrieve the list of shared folders the specified user has access to
+        /// </remarks>
+        /// <returns>
+        /// A list of Folder objects, representing shared folders of an user
+        /// </returns>
+        public IQuery<ODataFeed<Item>> GetAllSharedFoldersForSpecificUser(Uri url)
+        {
+            var sfApiQuery = new ShareFile.Api.Client.Requests.Query<ODataFeed<Item>>(Client);
+            sfApiQuery.Action("AllSharedFolders");
+            sfApiQuery.Uri(url);
+            sfApiQuery.HttpMethod = "GET";	
+            return sfApiQuery;
+        }
         
         /// <summary>
         /// Get List of User Shared Folders


### PR DESCRIPTION
This change will expose a new endpoint that was recently created in the API to allow a caller to request the list of Shared Folders for a specific user.  The current functionality only allows for the Shared Folders of the currently authenticated user to be returned.  This new call can only be made by a member of the Super User group within the Account.